### PR TITLE
Question and proposal for the logic in `desc' of `ext2`

### DIFF
--- a/learner/tensors/D-extend.rkt
+++ b/learner/tensors/D-extend.rkt
@@ -31,12 +31,15 @@
     (cond
       ((of-rank? n t) (desc-u g t u))
       ((of-rank? m u) (desc-t g t u))
-      ((= (tlen t) (tlen u)) (tmap g t u))
+      ((= (rank t) (rank u))
+       (if (= (tlen t) (tlen u))
+           (tmap g t u)
+           (error 'ext
+              "Shapes are incompatible for ext2: ~a and ~a for min ranks ~a and ~a~%"
+              (shape t) (shape u) n m)))
       ((rank> t u) (desc-t g t u))
       ((rank> u t) (desc-u g t u)) ;; Slight variation from the book, to add error checking
-      (else (error 'ext
-              "Shapes are incompatible for ext2: ~a and ~a for min ranks ~a and ~a~%"
-              (shape t) (shape u) n m)))))
+    )))
 
 (define desc-t
   (λ (g t u)


### PR DESCRIPTION
In the conditional check for `desc'. In the first `cond` form, the code compares `rank` and decides on which tensor to descend into; only when the ranks are the same, it would check the number of elements and descend into both if valid, or raise an error if not.

Would be clearer if the logic is written out as described above? Is there particular reason beside being concise for the original edition?