### PR TITLE
Fix Makefile for make set-nested-tensors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ set-learner:
 	$(RACKET) -e "(require malt/set-impl) (set-impl 'learner)"
 
 set-nested-tensors:
-	$(RACKET) -e "(require malt/set-impl) (set-impl 'nested)"
+	$(RACKET) -e "(require malt/set-impl) (set-impl 'nested-tensors)"
 
 set-flat-tensors:
 	$(RACKET) -e "(require malt/set-impl) (set-impl 'flat-tensors)"


### PR DESCRIPTION
Now using make set-nested-tensors to enable the nested-tensors representation works properly. Before it would throw an error saying "Unknown implementation: 'nested".

Looks like it was just a small typo in the makefile; the fix is pretty small and inconsequential. But I do find it to be a nice quality-of-life thing to switch easily between the tensor implementations with make!