### PR TITLE
Fix the wrong definition of >=-0-0.

### DIFF
--- a/learner/ext-ops/B-comparators.rkt
+++ b/learner/ext-ops/B-comparators.rkt
@@ -25,7 +25,7 @@
   (comparator >))
 
 (define >=-0-0
-  (comparator >))
+  (comparator >=))
 
 ;;----------------------------
 ;; Tensorized comparators


### PR DESCRIPTION
In the definition of `>=-0-0`, `>=` should be used instead of `>`.